### PR TITLE
[u-mr1] AndroidProducts: Set release configuration to AP2A

### DIFF
--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -15,5 +15,5 @@
 PRODUCT_MAKEFILES := $(LOCAL_DIR)/aosp_xqcc54.mk
 
 COMMON_LUNCH_CHOICES += \
-    aosp_xqcc54-eng \
-    aosp_xqcc54-userdebug
+    aosp_xqcc54-ap2a-eng \
+    aosp_xqcc54-ap2a-userdebug


### PR DESCRIPTION
Starting with the latest revisions of Android 14 the string
representing the target has the following format:
product_name-release_config-build_variant.
Most likely we will freeze on the r67 tag which provides
only the AP2A release config[1].

[1] https://android.googlesource.com/platform/build/release/+/refs/tags/android-14.0.0_r67/aconfig