### PR TITLE
[u-mr1] README.md: Update Sony Open Devices domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Copyright (C) Sony Mobile Communications 2021
 This is the Android device configuration for Xperia 10 IV (murray platform).
 
 Build instructions
-https://developer.sony.com/develop/open-devices/guides/aosp-build-instructions/
+https://opendevices.sony.net/aosp-on-xperia-open-devices/guides/aosp-build-instructions/


### PR DESCRIPTION
Sony's Developer World closed down on 8 May, 2026.
AOSP on Xperia Open Devices have moved to dedicated
https://opendevices.sony.net/ website.